### PR TITLE
Extract the translatable strings from XSL (bsc#1083720)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 doc/
 .yardoc/
 test/
+*.pot

--- a/package/installation.SLES4SAP.glade
+++ b/package/installation.SLES4SAP.glade
@@ -1,0 +1,1 @@
+installation.SLES4SAP.xsl

--- a/package/installation.SLES4SAP.xsl
+++ b/package/installation.SLES4SAP.xsl
@@ -11,6 +11,11 @@
   exclude-result-prefixes="n"
 >
 
+<!--
+Work around for the text domain
+textdomain="control"
+-->
+
 <xsl:output method="xml" indent="yes"/>
 
   <xsl:template match="node()|@*">

--- a/package/skelcd-control-SLES4SAP.changes
+++ b/package/skelcd-control-SLES4SAP.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Mar 22 14:31:19 UTC 2018 - lslezak@suse.cz
+
+- Enhance the XSL file so the translatable strings can be extracted
+  by the y2makepot tool (bsc#1083720)
+- 15.0.2
+
+-------------------------------------------------------------------
 Wed Jan 10 17:13:42 UTC 2018 - rbrown@suse.com
  
 - adjust subvolume list to have NoCOW /var instead of many

--- a/package/skelcd-control-SLES4SAP.spec
+++ b/package/skelcd-control-SLES4SAP.spec
@@ -46,7 +46,7 @@ Provides:       system-installation() = SLES_SAP
 
 Url:            https://github.com/yast/skelcd-control-SLES4SAP
 AutoReqProv:    off
-Version:        15.0.1
+Version:        15.0.2
 Release:        0
 Summary:        SLES4SAP control file needed for installation
 License:        MIT


### PR DESCRIPTION
- See https://bugzilla.suse.com/show_bug.cgi?id=1083720
- A XSL file is basically a XML file so we can use the usual trick as for the `control.xml` file:
  - Add a `texdomain` comment so the correct text domain is found by the `y2makepot` tool
  - Add a `*.glade` symlink 
- We just need to update the transformation to the glade format so it supports also XSL in addition to the YaST XML, see https://github.com/yast/yast-devtools/pull/129
- 15.0.2

When I run `rake pot` it now creates the `control.pot` file with this content:
```
#. TRANSLATORS: a label for a system role
#: package/installation.SLES4SAP.glade.translations.glade:2
msgid "SLES for SAP Applications"
msgstr ""

#: package/installation.SLES4SAP.glade.translations.glade:2
msgid ""
"• Ideal if you want to run an SAP Application\n"
"• RDP and SAP Installation Wizard option available"
msgstr ""
```

So the translatable strings are correctly found.