### PR TITLE
Move the .glade symlink out of package/

### DIFF
--- a/installation.SLES4SAP.glade
+++ b/installation.SLES4SAP.glade
@@ -1,0 +1,1 @@
+package/installation.SLES4SAP.xsl

--- a/package/installation.SLES4SAP.glade
+++ b/package/installation.SLES4SAP.glade
@@ -1,1 +1,0 @@
-installation.SLES4SAP.xsl


### PR DESCRIPTION
- An OBS check complains that this file is missing in the .spec
- See https://build.suse.de/request/show/159969
- Move it to the root directory so it's not submitted to OBS
- Ignore the Travis failure, it seems to be caused by some package update which requires a vendor change, unfortunately `zypper install` does not accept `--allow-vendor-change`... :worried: 