### PR TITLE
Added default preselected modules in offline installation (jsc#SLE-8040)

### DIFF
--- a/package/installation.SLES4SAP.xsl
+++ b/package/installation.SLES4SAP.xsl
@@ -156,4 +156,23 @@ textdomain="control"
         <xsl:apply-templates/>
       </xsl:copy>
   </xsl:template>
+
+  <!-- add a new "software/default_modules" section just after the "textdomain" -->
+  <xsl:template xml:space="preserve" match="n:textdomain">
+    <xsl:copy>
+      <xsl:apply-templates/>
+    </xsl:copy>
+
+    <software>
+      <xsl:comment> the default preselected modules in offline installation </xsl:comment>
+      <default_modules config:type="list">
+        <default_module>sle-ha</default_module>
+        <default_module>sle-module-basesystem</default_module>
+        <default_module>sle-module-desktop-applications</default_module>
+        <default_module>sle-module-sap-applications</default_module>
+        <default_module>sle-module-server-applications</default_module>
+      </default_modules>
+    </software>
+  </xsl:template>
+
 </xsl:stylesheet>

--- a/package/skelcd-control-SLES4SAP.changes
+++ b/package/skelcd-control-SLES4SAP.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Feb 26 11:19:54 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+
+- Added default preselected modules in offline installation
+  (jsc#SLE-8040)
+- 15.2.1
+
+-------------------------------------------------------------------
 Thu Oct 17 10:28:15 UTC 2019 - Josef Reidinger <jreidinger@suse.com>
 
 - Skip the registration step on the online and offline installation

--- a/package/skelcd-control-SLES4SAP.spec
+++ b/package/skelcd-control-SLES4SAP.spec
@@ -51,7 +51,7 @@ Provides:       system-installation() = SLES_SAP
 
 Url:            https://github.com/yast/skelcd-control-SLES4SAP
 AutoReqProv:    off
-Version:        15.2.0
+Version:        15.2.1
 Release:        0
 Summary:        SLES4SAP control file needed for installation
 License:        MIT


### PR DESCRIPTION
- Added the default preselected modules in offline installation
- Related to https://jira.suse.com/browse/SLE-8040 and https://jira.suse.com/browse/SLE-11455
- From JIRA: SLES for SAP: Basesystem, Server Application, SAP Applications, Desktop Applications, HA Extension (extension)
- 15.2.1