### PR TITLE
Fixed the default preselected modules (bsc#1178138)

### DIFF
--- a/package/installation.SLES4SAP.xsl
+++ b/package/installation.SLES4SAP.xsl
@@ -157,22 +157,15 @@ textdomain="control"
       </xsl:copy>
   </xsl:template>
 
-  <!-- add a new "software/default_modules" section just after the "textdomain" -->
-  <xsl:template xml:space="preserve" match="n:textdomain">
-    <xsl:copy>
-      <xsl:apply-templates/>
-    </xsl:copy>
-
-    <software>
-      <xsl:comment> the default preselected modules in offline installation </xsl:comment>
-      <default_modules config:type="list">
-        <default_module>sle-ha</default_module>
-        <default_module>sle-module-basesystem</default_module>
-        <default_module>sle-module-desktop-applications</default_module>
-        <default_module>sle-module-sap-applications</default_module>
-        <default_module>sle-module-server-applications</default_module>
-      </default_modules>
-    </software>
+  <!-- modify the default modules -->
+  <xsl:template xml:space="preserve" match="n:software/n:default_modules">
+        <default_modules config:type="list">
+            <default_module>sle-ha</default_module>
+            <default_module>sle-module-basesystem</default_module>
+            <default_module>sle-module-desktop-applications</default_module>
+            <default_module>sle-module-sap-applications</default_module>
+            <default_module>sle-module-server-applications</default_module>
+        </default_modules>
   </xsl:template>
 
 </xsl:stylesheet>

--- a/package/skelcd-control-SLES4SAP.changes
+++ b/package/skelcd-control-SLES4SAP.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Nov 24 09:24:17 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+
+- Fixed the default preselected modules when installing from
+  the Full medium (bsc#1178138)
+- 15.2.2
+
+-------------------------------------------------------------------
 Wed Feb 26 11:19:54 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
 
 - Added default preselected modules in offline installation

--- a/package/skelcd-control-SLES4SAP.spec
+++ b/package/skelcd-control-SLES4SAP.spec
@@ -51,7 +51,7 @@ Provides:       system-installation() = SLES_SAP
 
 Url:            https://github.com/yast/skelcd-control-SLES4SAP
 AutoReqProv:    off
-Version:        15.2.1
+Version:        15.2.2
 Release:        0
 Summary:        SLES4SAP control file needed for installation
 License:        MIT


### PR DESCRIPTION
- Fixed the default preselected modules when installing from the Full medium
- https://bugzilla.suse.com/show_bug.cgi?id=1178138
- Originally the SLES did not contain the defaults so we were **adding** the `default_modules` section
- Later SLES added the default values which resulted in having the section **twice** in SLES4SAp. Unfortunately the SLES4SAP section was added at the beginning of the file so during XML parsing the later SLES defaults overridden the added SLES4SAP defaults.
- Fixed by *modifying* the SLES defaults
- Review note: check the [diff without the whitespace changes](https://github.com/yast/skelcd-control-SLES4SAP/pull/18/files?diff=unified&w=1) (I added more indentation so the final XML looks better)

## Testing

- Tested manually
- You can see the [XSLT result at Travis](https://travis-ci.org/github/yast/skelcd-control-SLES4SAP/builds/745603370#L424-L430)