### PR TITLE
 Update dependency on skelcd-control-SLES

### DIFF
--- a/package/skelcd-control-SLES4SAP.changes
+++ b/package/skelcd-control-SLES4SAP.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Dec  3 10:12:52 UTC 2021 - David Diaz <dgonzalez@suse.com>
+
+- Update dependency on skelcd-control-SLES to version 15.4.1 to
+  remove the registration step (bsc#1193311).
+- 15.4.1
+
+-------------------------------------------------------------------
 Tue Apr 20 13:51:55 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - 15.4.0 (bsc#1185510)

--- a/package/skelcd-control-SLES4SAP.spec
+++ b/package/skelcd-control-SLES4SAP.spec
@@ -52,7 +52,7 @@ Provides:       system-installation() = SLES_SAP
 
 Url:            https://github.com/yast/skelcd-control-SLES4SAP
 AutoReqProv:    off
-Version:        15.4.0
+Version:        15.4.1
 Release:        0
 Summary:        SLES4SAP control file needed for installation
 License:        MIT

--- a/package/skelcd-control-SLES4SAP.spec
+++ b/package/skelcd-control-SLES4SAP.spec
@@ -37,8 +37,9 @@ BuildRequires:  libxml2-tools
 # Added skelcd macros
 BuildRequires: yast2-installation-control >= 4.1.5
 
-# Original SLES control file (skipping registration)
-BuildRequires: skelcd-control-SLES >= 15.3.2
+# Original SLES control file
+# (simplified workflow - https://github.com/yast/skelcd-control-SLES/pull/142)
+BuildRequires: skelcd-control-SLES >= 15.4.1
 BuildRequires: diffutils
 
 # Use FHS compliant path


### PR DESCRIPTION
## Problem

The installation workflow has been simplified (see https://github.com/yast/skelcd-control-leanos/pull/83, https://github.com/yast/skelcd-control-leanos/pull/84, and https://github.com/yast/skelcd-control-SLES/pull/141) but the dependency of this control file in skelcd-control-SLES was not updated. In consequence, the registration step is shown twice

* https://bugzilla.suse.com/show_bug.cgi?id=1193311

## Solution

Update dependency on skelcd-control-SLES to 15.4.1 
