### PR TITLE
Validate the built XML in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,10 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Install Prerequisites
-      run: rake build_dependencies:install
+      # use jing for validation instead of xmllint
+      run: |-
+        rake build_dependencies:install
+        zypper --non-interactive install --no-recommends jing
 
     # just for easier debugging...
     - name: Inspect Installed Packages
@@ -25,3 +28,11 @@ jobs:
 
     - name: Package Build
       run: yast-ci-ruby -o package
+
+    - name: Validate XML
+      # install the built RPM and validate the XML using jing
+      run: |-
+        rpm -iv --force --nodeps /usr/src/packages/RPMS/*/*.rpm
+        XML_FILES=$(rpm -qpl /usr/src/packages/RPMS/*/*.rpm | grep "\.xml$")
+        echo "Validating ${XML_FILES}..."
+        jing /usr/share/YaST2/control/control.rng $XML_FILES && echo "OK"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,4 @@ jobs:
       run: yast-ci-ruby -o package
 
     - name: Validate XML
-      # install the built RPM and validate the XML using jing
-      run: |-
-        rpm -iv --force --nodeps /usr/src/packages/RPMS/*/*.rpm
-        XML_FILES=$(rpm -qpl /usr/src/packages/RPMS/*/*.rpm | grep "\.xml$")
-        echo "Validating ${XML_FILES}..."
-        jing /usr/share/YaST2/control/control.rng $XML_FILES && echo "OK"
+      run: rake test:validate

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ doc/
 .yardoc/
 test/
 *.pot
+installation.SLES4SAP.xml

--- a/README.md
+++ b/README.md
@@ -9,4 +9,26 @@ product with modifications expressed in xslt.
 
 See also the [documentation for the `control.xml` file][1].
 
+
+## Building XML
+
+Run `rake build` to build the final XML file. By default it uses the base SLES
+XML file from the `skelcd-control-SLES` package.
+
+That can be changed via the `BASE_XML` environment variable to point to a Git
+checkout directly:
+``` shell
+BASE_XML=../skelcd-control-SLES/control/installation.SLES.xml rake build
+```
+
+## Validation
+
+Run `rake test:validation` to validate the built XML file. It uses `jing` for
+XML validation, if that is not installed it fallbacks to `xmllint` (which
+unfortunately has a worse error reporting).
+
+You can use the `BASE_XML` environment variable to set the base XML path,
+see above.
+
+
 [1]: https://github.com/yast/yast-installation/blob/master/doc/control-file.md

--- a/Rakefile
+++ b/Rakefile
@@ -7,3 +7,34 @@ end
 
 # no tarball is needed for package build
 Rake::Task["tarball"].clear_actions
+
+CONTROL_SCHEMA = "/usr/share/YaST2/control/control.rng".freeze
+XSL_FILE = "package/installation.SLES4SAP.xsl".freeze
+DEFAULT_BASE_XML = "/usr/share/installation-products/SLES.xml".freeze
+# allow using a custom base SLES file e.g. from a Git checkout
+BASE_XML = ENV["BASE_XML"] || DEFAULT_BASE_XML
+TARGET_XML = "installation.SLES4SAP.xml".freeze
+
+file TARGET_XML => [ XSL_FILE, BASE_XML ] do
+  sh "xsltproc", "--output", TARGET_XML, XSL_FILE, BASE_XML
+end
+
+desc "Build the XML (set the base SLES file via $BASE_XML, default: #{DEFAULT_BASE_XML})"
+task :build => TARGET_XML.to_sym
+
+desc "validate the XML"
+task :"test:validate" => TARGET_XML do
+  begin
+    # prefer using jing for validation
+    sh "jing", CONTROL_SCHEMA, TARGET_XML
+    puts "OK"
+  rescue Errno::ENOENT
+    # fallback to xmllint
+    sh "xmllint", "--noout", "--relaxng", CONTROL_SCHEMA, TARGET_XML
+  end
+end
+
+desc "Remove the generated XML file"
+task :clean do
+  rm TARGET_XML if File.exist?(TARGET_XML)
+end


### PR DESCRIPTION
- When fixing #23 I found out that we do not run the XML validation in GitHub Actions, let's fix that.
- See an [example run](https://github.com/yast/skelcd-control-SLES4SAP/runs/4411824264?check_suite_focus=true#step:7:10).